### PR TITLE
chore(project): Lint workflow invalid YAML test

### DIFF
--- a/tmp/bad-lint.yaml
+++ b/tmp/bad-lint.yaml
@@ -1,0 +1,2 @@
+name: lint
+  invalid: indentation


### PR DESCRIPTION
PR purposely introduces invalid YAML for lint workflow validation.